### PR TITLE
DEMO: HOW TO MODIFY version.py and setup.py for PyPI 0.1.0

### DIFF
--- a/fishersapi/version.py
+++ b/fishersapi/version.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
-from os.path import join as pjoin
+from os import path
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
 _version_minor = 1
 _version_micro = ''  # use '' for first of series, number for 1 and above
-_version_extra = 'dev'
-# _version_extra = ''  # Uncomment this for full releases
+#_version_extra = 'dev'
+_version_extra = ''  # Uncomment this for full releases
 
 # Construct full version string from these.
 _ver = [_version_major, _version_minor]
@@ -27,29 +27,19 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
 
 # Description should be a one-liner:
 description = "fishersapi: An API for applying a fast Fisher's Exact Test to variable pairs in pandas DataFrames"
-# Long description will go up on the pypi page
-long_description = """
 
-fishersapi
-========
-fishersapi provides an interface for running a fast implementation
-of Fisher's exact test for 2x2 tables on categorical data in 
-a pandas.DataFrame. The results are tested against scipy.stats.fishers_exact
-and fallback on scipy if the faster brentp/fishers_exact_test (~1000x faster)
-is not installed.
+# read the contents of your README file into long_description
+this_directory = path.abspath(path.dirname(path.dirname(__file__)))
 
-License
-=======
-``fishersapi`` is licensed under the terms of the MIT license. See the file
-"LICENSE" for information on the history of this software, terms & conditions
-for usage, and a DISCLAIMER OF ALL WARRANTIES.
-"""
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()    
 
 NAME = "fishersapi"
 MAINTAINER = "Andrew Fiore-Gartland"
 MAINTAINER_EMAIL = "agartlan@fredhutch.org"
 DESCRIPTION = description
 LONG_DESCRIPTION = long_description
+LONG_DESCRIPTION_CONTENT_TYPE = 'text/markdown' 
 URL = "http://github.com/agartland/fishersapi"
 DOWNLOAD_URL = ""
 LICENSE = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,12 @@ ver_file = os.path.join('fishersapi', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
 
-opts = dict(name=NAME,
+opts = dict(name='fisherapiX', # replace 'fisherapitest' with NAME once you are ready to upload to PyPi 
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
             description=DESCRIPTION,
             long_description=LONG_DESCRIPTION,
+            long_description_content_type=LONG_DESCRIPTION_CONTENT_TYPE, # this allows current GitHub README.md to be rendeder on PyPi
             url=URL,
             download_url=DOWNLOAD_URL,
             license=LICENSE,
@@ -22,9 +23,15 @@ opts = dict(name=NAME,
             version=VERSION,
             packages=PACKAGES,
             package_data=PACKAGE_DATA,
-            install_requires=REQUIRES,
+            #install_requires=REQUIRES,
             requires=REQUIRES)
 
+install_requires = ['numpy>=1.16.4',
+                    'pandas>=0.24.2',
+                    'scipy>=1.2.1',
+                    'fisher>=0.1.9'
+                    'statsmodels>=0.10.1'] 
 
 if __name__ == '__main__':
-    setup(**opts)
+    setup(**opts, install_requires = install_requires)
+


### PR DESCRIPTION
I tested these changes and was able to upload fisherapiX 0.1 on PyPi
https://pypi.org/project/fisherapiX/0.1/.  (I will remove this in the next couple of days once you've had a chance to view the look and feel of the current README on PyPi)

## Here are the steps you would make to publish the real version:
1. See line 10 in setup.py. CHANGE name = 'fisherapiX' to NAME, so that name of package is specified in fishersapi/version.py 
2. Consider the  appropriate actual minimum versions specified in install_requires line 29-33 of setup.py 
3. Make edits and draft a release 0.1.0 on github (if making these edits by hand) or 0.1.1 if you merge this pull request. 

## Install to PyPi

## things to install and setup first
1. get a PyPi account username and password
2. Ensure you have recent setuptools `pip install --user --upgrade setuptools wheelinstall`
3. Install twine : pip install --upgrade twine 
4. Ok, Now, you're ready

### build the distribution using setuptools:
```
python3 setup.py sdist bdist_wheel
```

this will create a dict/ dir with two components:

in my case
```
fisherapiX-0.1-py3-none-any.whl  
fisherapiX-0.1.tar.gz
```
in your case, they should be:
```
fishersapi-0.1-py3-none-any.whl  
fishersapi-0.1.tar.gz
```

### Upload these Distribution Files to PyPI
```
twine upload dist/fisherapiX-0.1*
```

### Optional
create a `MANIFEST.in` file if you want to include package files along with code
create a `HISTORY.md` for tracking new features with each release

